### PR TITLE
Display contestant avatars in the leaderboard

### DIFF
--- a/src/components/LeaderboardTile.svelte
+++ b/src/components/LeaderboardTile.svelte
@@ -18,7 +18,7 @@
     <div class="profile">
       <h3>{r.name}</h3>
       <div class="subtitle">
-        <div class="icon"><Github /></div>
+        <img src={`https://avatars.githubusercontent.com/${r.profile}`} class="icon"  alt={r.profile} />
         <a rel="noopener" href="https://github.com/{r.profile}" target="_blank"
           >{l2p(r.profile)}</a
         >


### PR DESCRIPTION
added display contenstant avatars using github avatar api `https://avatars.githubusercontent.com/${r.profile}` where r.profile is username of contestant