### PR TITLE
Fixed Leaderboard Sorting issue

### DIFF
--- a/src/stores/leaderboard.js
+++ b/src/stores/leaderboard.js
@@ -139,9 +139,9 @@ export const rankify = () => {
       p.name = titleCase(p.name);
     });
     lb.sort((a, b) => (b.name > a.name ? -1 : 1));
-    lb.sort((a,b) => b.easy - a.easy);
-    lb.sort((a,b) => b.medium - a.medium);
-    lb.sort((a,b) => b.hard - a.hard);
+    lb.sort((a, b) => b.easy - a.easy);
+    lb.sort((a, b) => b.medium - a.medium);
+    lb.sort((a, b) => b.hard - a.hard);
     lb.sort((a, b) => b.score - a.score);
 
     lb.forEach((p, i) => {


### PR DESCRIPTION
I have tried to fix the ranking issues of the leaderboard. Now the ranking is given in the following order (lowest criterion gets the lowest precedence)

- Total score
- Number of hard issues solved
- Number of medium issues solved
- Number of easy issues solved
- Alphabetical order of name

This closes #18 